### PR TITLE
Promisified the `request` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ you may want to have a look at mws-advanced: http://www.github.com/ericblade/mws
 
 Defaults to US marketplace settings, but can code to override default
 
-v2 and master branches requires node v8 or v9, tested with v8.9.4 and higher. Use v1 branch if you require
+v2,v3 branches requires node v8 or v9, tested with v8.9.4 and higher. Use v1 branch if you require
 older versions of node for some reason.
 
 ## Installation
@@ -180,10 +180,9 @@ Yes, please!
 
 Thank you!
 
-* [avrtau](https://github.com/avrtau) Avraham Tauberman
 * [ericblade](https://github.com/ericblade) Eric Blade
 * [tomjnsn](https://github.com/tomjnsn) Tom Jensen
-* [ebusinessdirect](https://github.com/ebusinessdirect) Original Author, Roger Endo
+* [ebusinessdirect](https://github.com/ebusinessdirect) Original Author
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ you may want to have a look at mws-advanced: http://www.github.com/ericblade/mws
 
 Defaults to US marketplace settings, but can code to override default
 
-v2,v3 branches requires node v8 or v9, tested with v8.9.4 and higher. Use v1 branch if you require
+v2 and master branches requires node v8 or v9, tested with v8.9.4 and higher. Use v1 branch if you require
 older versions of node for some reason.
 
 ## Installation
@@ -180,9 +180,10 @@ Yes, please!
 
 Thank you!
 
+* [avrtau](https://github.com/avrtau) Avraham Tauberman
 * [ericblade](https://github.com/ericblade) Eric Blade
 * [tomjnsn](https://github.com/tomjnsn) Tom Jensen
-* [ebusinessdirect](https://github.com/ebusinessdirect) Original Author
+* [ebusinessdirect](https://github.com/ebusinessdirect) Original Author, Roger Endo
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -41,21 +41,34 @@ If the API has an endpoint as specified in the documentation, put the endpoint i
 
 For uploading data to MWS, populate `feedContent` with a `buffer` of data.
 
-###### Invoke `request` with your request object.
+###### Invoke `request` with your request object
+###### [Callback]
 
 ````
-mws.request(requestObj, function (err, res, headers) {
+mws.request(requestObj, function (err, {res, headers}) {
   ....
 });
 ````
 
+###### [Promise]
+````
+mws.request(requestObj)
+  .then(({result, headers}) => {
+    ....
+  })
+  .catch(error => {
+    ....
+  });
+````
+
 ###### Check your error, response, and headers
 
-Note that there are three arguments that should be used for the callback:
+Note that there are two arguments that should be used for the callback:
 
 - err: any error information returned
-- res: the response information
-- headers: any headers returned from the call
+- result object:
+  - res: the response information
+  - headers: any headers returned from the call
 
 If you receive an error, you will not likely receive anything other than undefined or null for res.
 Most requests should supply headers.  Headers that a developer may be particularly interested in are
@@ -86,10 +99,18 @@ let listOrders = {
   }
 }
 
-mws.request(listOrders, function(e, result, headers) {
+// Callback:
+mws.request(listOrders, function(e, {result, headers}) {
   console.log(JSON.stringify(headers));
   console.log(JSON.stringify(result));
 });
+
+// Promise:
+mws.request(listOrders)
+  .then(({result, headers}) => {
+    console.log(JSON.stringify(headers));
+    console.log(JSON.stringify(result));
+  });
 ```
 
 ### Submit Shipments File:
@@ -104,8 +125,16 @@ let submitFeed = {
     FeedType: '_POST_FLAT_FILE_FULFILLMENT_DATA_'
   }
 };
-mws.request(submitFeed, function(e, result) {
+
+// Callback
+mws.request(submitFeed, function(e, {result, headers}) {
 });
+
+// Promise
+mws.request(submitFeed)
+  .then(({result, headers}) => {
+    ...
+  });
 
 ```
 
@@ -118,7 +147,9 @@ const query = {
         Version: '2018-02-14',
     },
 };
-mws.request(query, (err, result) => {
+
+// Callback
+mws.request(query, (err, {result, headers}) => {
     if (err instanceOf(mws.ServerError)) {
       console.warn('** Server Error', err.message, err.code, err.body);
     } else if (err) {
@@ -127,6 +158,18 @@ mws.request(query, (err, result) => {
       console.log('* Result', result);
     }
 });
+
+// Promise
+mws.request(query)
+  .catch(err => {
+    if (err instanceof mws.ServerError) {
+      console.warn('** Server Error', err.message, err.code, err.body);
+    } else if (err) {
+      console.warn('** Other Error', err);
+    } else {
+      console.log('* Result', result);
+    }
+  });
 ```
 
 ## Contributing

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -10,7 +10,7 @@ module.exports = (options, debug = {}, cb) => {
             if (file) {
                 syncWriteToFile(file, data);
             }
-            cb(err, result, response.headers);
+            cb(err, {result: result, headers: response.headers});
         }
 
         if (debug.rawFile) {
@@ -18,10 +18,10 @@ module.exports = (options, debug = {}, cb) => {
         }
 
         if (error) {
-            return cb(error instanceof Error ? error : new Error(error), undefined, response && response.headers);
+            return cb(error instanceof Error ? error : new Error(error), {result: undefined, headers: response && response.headers});
         }
         if (response.statusCode < 200 || response.statusCode > 299) {
-            return cb(new ServerError(response.statusMessage, response.statusCode, response.body), undefined, response && response.headers);
+            return cb(new ServerError(response.statusMessage, response.statusCode, response.body), {result: undefined, headers: response && response.headers});
         }
 
         let contentType = response.headers.hasOwnProperty('content-type') && response.headers['content-type'];

--- a/mws-simple.js
+++ b/mws-simple.js
@@ -6,25 +6,26 @@ const getContentType = require('./lib/getContentType');
 
 const { name: pkgAppId, version: pkgAppVersionId } = require('./package.json'); // pkgAppId=name, pkgAppVersionId=version
 
+function promisify (data) {
+    return new Promise ((resolve, reject) => {
+        this.request(data, (err, result) => 
+            err ? reject(err) : resolve(result))
+    });
+}
+
 class MWSSimple {
     constructor({ appId = pkgAppId, appVersionId = pkgAppVersionId, host = 'mws.amazonservices.com', port = 443, accessKeyId, secretAccessKey, merchantId, authToken } = {}) {
         Object.assign(this, { appId, appVersionId, host, port, accessKeyId, secretAccessKey, merchantId, authToken, ServerError });
         
         // allows to use this inside the request method
-        this.request = this.request.bind(this);
+        promisify = promisify.bind(this);
     }
 
     // http://docs.developer.amazonservices.com/en_US/dev_guide/DG_ClientLibraries.html
     request(requestData, callback, debugOptions) {
-        const self = this.request;
-
         // if no callback specified return a Promise
         if (callback === undefined) {
-            return new Promise ((resolve, reject) => {
-                self(requestData, (err, result) => {
-                    err ? reject(err) : resolve(result);
-                });
-            });
+            return promisify(requestData);
         }
 
         const requestDefaults = {

--- a/mws-simple.js
+++ b/mws-simple.js
@@ -17,7 +17,7 @@ class MWSSimple {
     constructor({ appId = pkgAppId, appVersionId = pkgAppVersionId, host = 'mws.amazonservices.com', port = 443, accessKeyId, secretAccessKey, merchantId, authToken } = {}) {
         Object.assign(this, { appId, appVersionId, host, port, accessKeyId, secretAccessKey, merchantId, authToken, ServerError });
         
-        // allows to use this inside the request method
+        // allows to use this inside the promisify method
         promisify = promisify.bind(this);
     }
 

--- a/mws-simple.js
+++ b/mws-simple.js
@@ -6,26 +6,25 @@ const getContentType = require('./lib/getContentType');
 
 const { name: pkgAppId, version: pkgAppVersionId } = require('./package.json'); // pkgAppId=name, pkgAppVersionId=version
 
-function promisify (data) {
-    return new Promise ((resolve, reject) => {
-        this.request(data, (err, result) => 
-            err ? reject(err) : resolve(result))
-    });
-}
-
 class MWSSimple {
     constructor({ appId = pkgAppId, appVersionId = pkgAppVersionId, host = 'mws.amazonservices.com', port = 443, accessKeyId, secretAccessKey, merchantId, authToken } = {}) {
         Object.assign(this, { appId, appVersionId, host, port, accessKeyId, secretAccessKey, merchantId, authToken, ServerError });
         
         // allows to use this inside the request method
-        promisify = promisify.bind(this);
+        this.request = this.request.bind(this);
     }
 
     // http://docs.developer.amazonservices.com/en_US/dev_guide/DG_ClientLibraries.html
     request(requestData, callback, debugOptions) {
+        const self = this.request;
+
         // if no callback specified return a Promise
         if (callback === undefined) {
-            return promisify(requestData);
+            return new Promise ((resolve, reject) => {
+                self(requestData, (err, result) => {
+                    err ? reject(err) : resolve(result);
+                });
+            });
         }
 
         const requestDefaults = {

--- a/mws-simple.js
+++ b/mws-simple.js
@@ -17,7 +17,7 @@ class MWSSimple {
     constructor({ appId = pkgAppId, appVersionId = pkgAppVersionId, host = 'mws.amazonservices.com', port = 443, accessKeyId, secretAccessKey, merchantId, authToken } = {}) {
         Object.assign(this, { appId, appVersionId, host, port, accessKeyId, secretAccessKey, merchantId, authToken, ServerError });
         
-        // allows to use this inside the promisify method
+        // allows to use this inside the request method
         promisify = promisify.bind(this);
     }
 

--- a/mws-simple.js
+++ b/mws-simple.js
@@ -9,10 +9,24 @@ const { name: pkgAppId, version: pkgAppVersionId } = require('./package.json'); 
 class MWSSimple {
     constructor({ appId = pkgAppId, appVersionId = pkgAppVersionId, host = 'mws.amazonservices.com', port = 443, accessKeyId, secretAccessKey, merchantId, authToken } = {}) {
         Object.assign(this, { appId, appVersionId, host, port, accessKeyId, secretAccessKey, merchantId, authToken, ServerError });
+        
+        // allows to use this inside the request method
+        this.request = this.request.bind(this);
     }
 
     // http://docs.developer.amazonservices.com/en_US/dev_guide/DG_ClientLibraries.html
     request(requestData, callback, debugOptions) {
+        const self = this.request;
+
+        // if no callback specified return a Promise
+        if (callback === undefined) {
+            return new Promise ((resolve, reject) => {
+                self(requestData, (err, result) => {
+                    err ? reject(err) : resolve(result);
+                });
+            });
+        }
+
         const requestDefaults = {
             path: '/',
             query: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mws-simple",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "nodejs Amazon MWS API in ~150 lines of code",
   "main": "mws-simple.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mws-simple",
-  "version": "4.0.0",
+  "version": "3.0.0",
   "description": "nodejs Amazon MWS API in ~150 lines of code",
   "main": "mws-simple.js",
   "dependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -134,7 +134,7 @@ describe('API tests', () => {
                 Version: '2018-02-14',
             },
         };
-        mwsApi.request(query, (err, result, headers) => {
+        mwsApi.request(query, (err, { result, headers }) => {
             expect(err).to.be.an.instanceOf(mwsApi.ServerError);
             expect(result).to.equal(undefined);
             expect(headers).to.be.an('object').that.has.keys([
@@ -148,6 +148,24 @@ describe('API tests', () => {
             done();
         });
     });
+    it('request with no callback returns a Promise', async function testPromise() {
+        const query = {
+            path: '/Test/Test',
+            query: {
+                Action: 'TestForPromise',
+                Version: '2018-02-14',
+            },
+        };
+        const p = mwsApi.request(query);
+        expect(p).to.be.an.instanceOf(Promise);
+        try {
+            await p;
+        } catch (err) {
+            expect(err.message).to.equal('Not Found');
+            expect(err.code).to.equal(404);
+            expect(err.body).to.be.a('string');
+        }
+    });
     // we generally don't use this call because it has an extremely low throttle rate, according to the docs.
     // it('GetServiceStatus', function testThrottle(done) {
     //     const query = {
@@ -157,9 +175,9 @@ describe('API tests', () => {
     //             Version: '2011-07-01',
     //         },
     //     };
-    //     mwsApi.request(query, (err, res) => {
+    //     mwsApi.request(query, (err, { result, headers }) => {
     //         console.warn('**** err', JSON.stringify(err, null, 4));
-    //         console.warn('***** res', JSON.stringify(res, null, 4));
+    //         console.warn('***** res', JSON.stringify(result, null, 4));
     //         done();
     //     });
     // });
@@ -171,7 +189,7 @@ describe('API tests', () => {
                 Version: '2011-07-01',
             },
         };
-        mwsApi.request(query, (err, result, headers) => {
+        mwsApi.request(query, (err, { result, headers }) => {
             if (err) {
                 done(err);
                 return false;
@@ -205,7 +223,7 @@ describe('API tests', () => {
         };
         mwsApi.request(
             query,
-            (err, result) => {
+            (err, { result, headers }) => {
                 expect(fs.existsSync('./test-rawdata.txt')).to.equal(true);
                 expect(fs.existsSync('./test-parseddata.txt')).to.equal(true);
                 fs.unlinkSync('./test-rawdata.txt');
@@ -226,7 +244,7 @@ describe('API tests', () => {
                 ItemCondition: 'New',
             },
         };
-        mwsApi.request(query, (err, result, headers) => {
+        mwsApi.request(query, (err, { result, headers }) => {
             if (err) {
                 done(err);
                 return;
@@ -265,12 +283,12 @@ describe('API tests', () => {
             feedContent: require('fs').readFileSync('./test/test-feed.txt'),
             ...query,
         };
-        mwsApi.request(submitFeed, function(err, res) {
+        mwsApi.request(submitFeed, function(err, { result, headers }) {
             expect(err).to.be.null;
-            expect(res).to.be.an('object').with.keys(
+            expect(result).to.be.an('object').with.keys(
                 [ 'SubmitFeedResponse', ],
             );
-            const x = res.SubmitFeedResponse;
+            const x = result.SubmitFeedResponse;
             expect(x).to.be.an('object').with.keys(
                 ['$', 'SubmitFeedResult', 'ResponseMetadata']
             );
@@ -295,7 +313,7 @@ describe('API tests', () => {
                 'FeesEstimateRequestList.FeesEstimateRequest.1.PriceToEstimateFees.Points.PointsNumber': '0',
             },
         };
-        mwsApi.request(query, (err, result) => {
+        mwsApi.request(query, (err, { result, headers }) => {
             // console.warn('* err=', err);
             // console.warn('* result=', result);
             expect(result).to.be.an('object').and.contain.key('GetMyFeesEstimateResponse');

--- a/test/test.js
+++ b/test/test.js
@@ -134,7 +134,7 @@ describe('API tests', () => {
                 Version: '2018-02-14',
             },
         };
-        mwsApi.request(query, (err, { result, headers }) => {
+        mwsApi.request(query, (err, result, headers) => {
             expect(err).to.be.an.instanceOf(mwsApi.ServerError);
             expect(result).to.equal(undefined);
             expect(headers).to.be.an('object').that.has.keys([
@@ -148,24 +148,6 @@ describe('API tests', () => {
             done();
         });
     });
-    it('request with no callback returns a Promise', async function testPromise() {
-        const query = {
-            path: '/Test/Test',
-            query: {
-                Action: 'TestForPromise',
-                Version: '2018-02-14',
-            },
-        };
-        const p = mwsApi.request(query);
-        expect(p).to.be.an.instanceOf(Promise);
-        try {
-            await p;
-        } catch (err) {
-            expect(err.message).to.equal('Not Found');
-            expect(err.code).to.equal(404);
-            expect(err.body).to.be.a('string');
-        }
-    });
     // we generally don't use this call because it has an extremely low throttle rate, according to the docs.
     // it('GetServiceStatus', function testThrottle(done) {
     //     const query = {
@@ -175,9 +157,9 @@ describe('API tests', () => {
     //             Version: '2011-07-01',
     //         },
     //     };
-    //     mwsApi.request(query, (err, { result, headers }) => {
+    //     mwsApi.request(query, (err, res) => {
     //         console.warn('**** err', JSON.stringify(err, null, 4));
-    //         console.warn('***** res', JSON.stringify(result, null, 4));
+    //         console.warn('***** res', JSON.stringify(res, null, 4));
     //         done();
     //     });
     // });
@@ -189,7 +171,7 @@ describe('API tests', () => {
                 Version: '2011-07-01',
             },
         };
-        mwsApi.request(query, (err, { result, headers }) => {
+        mwsApi.request(query, (err, result, headers) => {
             if (err) {
                 done(err);
                 return false;
@@ -223,7 +205,7 @@ describe('API tests', () => {
         };
         mwsApi.request(
             query,
-            (err, { result, headers }) => {
+            (err, result) => {
                 expect(fs.existsSync('./test-rawdata.txt')).to.equal(true);
                 expect(fs.existsSync('./test-parseddata.txt')).to.equal(true);
                 fs.unlinkSync('./test-rawdata.txt');
@@ -244,7 +226,7 @@ describe('API tests', () => {
                 ItemCondition: 'New',
             },
         };
-        mwsApi.request(query, (err, { result, headers }) => {
+        mwsApi.request(query, (err, result, headers) => {
             if (err) {
                 done(err);
                 return;
@@ -283,12 +265,12 @@ describe('API tests', () => {
             feedContent: require('fs').readFileSync('./test/test-feed.txt'),
             ...query,
         };
-        mwsApi.request(submitFeed, function(err, { result, headers }) {
+        mwsApi.request(submitFeed, function(err, res) {
             expect(err).to.be.null;
-            expect(result).to.be.an('object').with.keys(
+            expect(res).to.be.an('object').with.keys(
                 [ 'SubmitFeedResponse', ],
             );
-            const x = result.SubmitFeedResponse;
+            const x = res.SubmitFeedResponse;
             expect(x).to.be.an('object').with.keys(
                 ['$', 'SubmitFeedResult', 'ResponseMetadata']
             );
@@ -313,7 +295,7 @@ describe('API tests', () => {
                 'FeesEstimateRequestList.FeesEstimateRequest.1.PriceToEstimateFees.Points.PointsNumber': '0',
             },
         };
-        mwsApi.request(query, (err, { result, headers }) => {
+        mwsApi.request(query, (err, result) => {
             // console.warn('* err=', err);
             // console.warn('* result=', result);
             expect(result).to.be.an('object').and.contain.key('GetMyFeesEstimateResponse');


### PR DESCRIPTION
FEATURE: request method now returns a Promise if no callback is specified.

BREAKING CHANGE: Callback for makeRequest parameter change from (error, result, headers) to (error, {result, headers}).

Documentation is updated